### PR TITLE
Instead of hiding all minor publishing buttons (like save and preview), only hide preview

### DIFF
--- a/scss/post-admin.scss
+++ b/scss/post-admin.scss
@@ -20,7 +20,7 @@
 
 }
 
-#visibility, #minor-publishing-actions {
+#visibility, #preview-action {
 	display: none;
 }
 


### PR DESCRIPTION
Without the Save Draft / Save button, it's difficult to stage feeds that are not ready. In a client <> developer project, this can be critical to ensuring things are ready prior to launch of such features or new series of content.

I have purposefully not made the associated changes to the .css files in case this needs further discussion / review.