### PR TITLE
Add support for user agent override in the request args for wp_remote_get

### DIFF
--- a/includes/class-fp-pull.php
+++ b/includes/class-fp-pull.php
@@ -166,7 +166,9 @@ class FP_Pull {
 			fclose( $file_handle );
 
 		} else {
-			$request = wp_remote_get( $url_or_path );
+			$args = apply_filters( 'fp_fetch_feed_request_args', array(), $url_or_path );
+
+			$request = wp_remote_get( $url_or_path, $args );
 
 			if ( is_wp_error( $request ) ) {
 				return $request;


### PR DESCRIPTION
New filter `fp_fetch_feed_request_args` lets you override the `user-agent` Feed Pull uses, or any other request args.