### PR TITLE
Check if $feed is strictly false to detect if feed was not parsed

### DIFF
--- a/includes/class-fp-pull.php
+++ b/includes/class-fp-pull.php
@@ -227,7 +227,7 @@ class FP_Pull {
 		// Suppress all warnings/errors for this
 		$feed = @simplexml_load_string( $raw_feed_contents );
 
-		if ( ! $feed ) {
+		if ( false === $feed ) {
 			$this->log( __( 'Feed could not be parsed', 'feed-pull' ), $source_feed_id, 'error' );
 
 			$this->handle_feed_log( $source_feed_id );


### PR DESCRIPTION
For feeds that have prefixed items (rss:item etc) they return an empty SimpleXMLElement object (custom namespaces not loaded up, nothing is there yet). This doesn't mean the feed was not parsed, it just means that the object has no elements yet.

By changing the line from `if ( ! $feed )` to `if ( false === $feed )` this resolves that issue, since the feed parse line is `$feed = @simplexml_load_string( $raw_feed_contents );`