### PR TITLE
Admin "Do Feed Pull" button should pull a feed manually and bypass the enable_feed_pull option

### DIFF
--- a/includes/class-fp-ajax.php
+++ b/includes/class-fp-ajax.php
@@ -69,7 +69,10 @@ class FP_AJAX {
 				$output['success'] = false;
 			}
 			else {
-				new FP_Pull( $source_feed_id );
+				new FP_Pull( false );
+				
+				// Do manual pull
+				$this->do_pull( $source_feed_id, true );
 
 				$feed_cpt = FP_Source_Feed_CPT::factory();
 

--- a/includes/class-fp-pull.php
+++ b/includes/class-fp-pull.php
@@ -400,14 +400,15 @@ class FP_Pull {
 	 * Pull from all our source feeds
 	 *
 	 * @param int|null $source_feed_id Source Feed ID to pull one feed or null to pull all
+	 * @param boolean $manual_pull Is this a manual pull (bypass feed pull enabled option)
 	 * @since 0.1.0
 	 */
-	private function do_pull( $source_feed_id = null ) {
+	private function do_pull( $source_feed_id = null, $manual_pull = false ) {
 
 		// Do nothing if feed pulling is not turned on
 		$option = fp_get_option();
 
-		if ( empty( $option['enable_feed_pull'] ) ) {
+		if ( empty( $option['enable_feed_pull'] ) && ! $manual_pull ) {
 			return;
 		}
 


### PR DESCRIPTION
For cases when you want to disable automatic feed pulls, but enable manual pulls at will.