### PR TITLE
Generate URLs correctly (for support in non-standard installs).

### DIFF
--- a/includes/class-fp-feed-pull.php
+++ b/includes/class-fp-feed-pull.php
@@ -146,7 +146,7 @@ class FP_Feed_Pull {
 							<th scope="row"><label for="fp_enable_feed_pull"><?php _e( 'Reset deleted syndicated posts:', 'feed-pull' ); ?></label></th>
 							<td>
 								<input class="button" type="button" id="fp_reset_deleted_syndicated_posts" id="fp_reset_deleted_syndicated_posts" value="<?php _e( 'Reset Deleted Posts', 'feed-pull' ); ?>">
-								<img style="vertical-align: middle; opacity: 0; margin-left: .3em;" id="fp-spinner" src="<?php echo home_url( '/wp-includes/images/wpspin.gif' ); ?>">
+								<img style="vertical-align: middle; opacity: 0; margin-left: .3em;" id="fp-spinner" src="<?php echo includes_url( '/images/wpspin.gif' ); ?>">
 								<p><?php _e( "Feed Pull won't resync posts that have been deleted. If you want to resync posts that have been deleted, you can reset that cache.", 'feed-pull' ); ?></p>
 							</td>
 						</tr>

--- a/includes/class-fp-source-feed-cpt.php
+++ b/includes/class-fp-source-feed-cpt.php
@@ -187,7 +187,7 @@ class FP_Source_Feed_CPT {
 		<p><?php _e( 'Click this button to manually pull from this feed otherwise you will have to wait for the cron job to execute.', 'feed-pull' ); ?></p>
 		<div class="button-container">
 			<input type="button" class="button" value="<?php _e( 'Do Feed Pull', 'feed-pull' ); ?>" id="fp_manual_pull">
-			<img id="fp-spinner" src="<?php echo home_url( '/wp-includes/images/wpspin.gif' ); ?>">
+			<img id="fp-spinner" src="<?php echo includes_url( '/images/wpspin.gif' ); ?>">
 		</div>
 	<?php
 	}


### PR DESCRIPTION
The location of `/wp-includes` isn't guaranteed to be at the document root, so the `includes_url()` function should be used to generate these image URLs.