### PR TITLE
Add filter fp_post_taxonomy_name for changing the taxonomy we auto ap…

### DIFF
--- a/includes/class-fp-pull.php
+++ b/includes/class-fp-pull.php
@@ -368,7 +368,7 @@ class FP_Pull {
 					if ( ! empty( $post_categories ) ) {
 						$sanitized_post_categories = array_map( 'absint', $post_categories );
 
-						wp_set_object_terms( $new_post_id, apply_filters( 'fp_post_categories', $sanitized_post_categories ), 'category', $update );
+						wp_set_object_terms( $new_post_id, apply_filters( 'fp_post_categories', $sanitized_post_categories ), apply_filters( 'fp_post_taxonomy_name', 'category' ), $update );
 					}
 
 					// Mark the post as syndicated

--- a/includes/class-fp-source-feed-cpt.php
+++ b/includes/class-fp-source-feed-cpt.php
@@ -338,12 +338,13 @@ class FP_Source_Feed_CPT {
 			</select>
 		</p>
 
-		<?php $cats = get_categories( array( 'hide_empty' => 0 ) ); ?>
+		<?php $terms = get_terms( apply_filters( 'fp_post_taxonomy_name', 'category' ), array( 'hide_empty' => 0 ) ); ?>
 		<p>
-			<label for="fp_new_post_categories"><?php _e( 'Automatically Add New Posts to Categories:', 'feed-pull' ); ?></label>
+			<?php $taxonomy = get_taxonomy( apply_filters( 'fp_post_taxonomy_name', 'category' ) ); ?>
+			<label for="fp_new_post_categories"><?php echo sprintf( __( 'Automatically Add New Posts to %s:', 'feed-pull' ), $taxonomy->label ); ?></label>
 			<select id="fp_new_post_categories" name="fp_new_post_categories[]" multiple="multiple">
-				<?php foreach ( $cats as $cat ) : ?>
-					<option <?php selected( in_array( $cat->term_id, $current_cats ), true ); ?> value="<?php echo (int) $cat->term_id; ?>"><?php echo esc_html( $cat->category_nicename ); ?></option>
+				<?php foreach ( $terms as $term ) : ?>
+					<option <?php selected( in_array( $term->term_id, $current_cats ), true ); ?> value="<?php echo (int) $term->term_id; ?>"><?php echo esc_html( $term->name ); ?></option>
 				<?php endforeach; ?>
 			</select>
 		</p>


### PR DESCRIPTION
Added a filter to specify a different taxonomy for mapping terms to new posts.
Defaults to category as it currently is.

One string change. No updates to translations.

add_filter( 'fp_post_taxonomy_name', function( $taxonomy_name ) { return 'my_taxonomy' } );